### PR TITLE
chore: update TypeScript peerDep version in @storybook/angular for Angular 11-rc

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -73,7 +73,7 @@
     "@angular/platform-browser-dynamic": ">=6.0.0",
     "@babel/core": "*",
     "rxjs": "^6.0.0",
-    "typescript": "^3.4.0",
+    "typescript": ">=3.4.0",
     "zone.js": "^0.8.29 || ^0.9.0 || ^0.10.0"
   },
   "engines": {


### PR DESCRIPTION
`@storybook/angular` should be compatible with Angular 11 which requires TypeScript 4.0
This resolves #12859 by supporting any version above Angular 6 through the latest RC

Issue:

## What I did
Update @storybook/angular peerDep for Angular 11

## How to test
- Is this testable with Jest or Chromatic screenshots? No
- Does this need a new example in the kitchen sink apps? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
